### PR TITLE
Update footer Privacy policy link

### DIFF
--- a/doc/footer.html
+++ b/doc/footer.html
@@ -8,5 +8,5 @@
     <strong>Radboud University</strong>
 
     &middot;
-    <a href="https://data-acc.ru.nl/doc/privacy_policy.html">Privacy Policy</a>
+    <a href="https://data.ru.nl/doc/privacy_policy.html">Privacy Policy</a>
 </small>


### PR DESCRIPTION
In the footer on the RDR homepage: changed the link  to the privacy policy from acceptance environment 

> https://data-acc.ru.nl/doc/privacy_policy.html

 to production environment 

> https://data.ru.nl/doc/privacy_policy.html