### PR TITLE
Changed URL on Thunar and Cyberduck page

### DIFF
--- a/doc/help/user-manual/transfer-data/cyberduck.rst
+++ b/doc/help/user-manual/transfer-data/cyberduck.rst
@@ -29,7 +29,7 @@ A new pop-up window will appear. In this window you must configure the bookmark 
 
 - **WebDAV (HTTP/SSL)**
 - **Nickname: add a freely chosen nickname to the new connection**
-- Server: **${repositoryWebdavUrl}**
+- Server: **webdav.${repositoryHostname}**
 - Port: **443**
 - Username: the *username* (CASE SENSITIVE!) of the :ref:`data access account <data-access-account>`
 

--- a/doc/help/user-manual/transfer-data/thunar.rst
+++ b/doc/help/user-manual/transfer-data/thunar.rst
@@ -25,7 +25,7 @@ Alternatively, you could also open the Thunar file manager with the command in a
 
 .. figure:: images/shell-thunar.png
 
-A file manager window will appear. In the browser bar at the top, type the following address: `davs://webdav.${repositoryWebdavUrl}`.
+A file manager window will appear. In the browser bar at the top, type the following address: `davs://webdav.${repositoryHostname}`.
 
 .. figure:: images/thunar-webdav-address.png
 


### PR DESCRIPTION
As asked for by Jessica and originally Marek Tyc.
Changed the webdav URL on the Thunar page (removed https:// in the middle of the sequence)
Also changed it on the Cyberduck page, where under 'server' the https:// was also visible.