### PR TITLE
Update FAQ- publish data- q11

### DIFF
--- a/doc/help/faq/publish-data.rst
+++ b/doc/help/faq/publish-data.rst
@@ -147,7 +147,7 @@ Publish data
 
 11. **What if a 'published' Data Sharing Collection (DSC) contains incorrect information?**
 
-    If a 'published' DSC contains incorrect and/or insufficient information, a collection manager may ask the research administrator to make it 'editable' again, allowing for changes to be made. If this DSC is modified and thereafter changed to 'published' again, then a second read-only copy is generated, with another unique persistent identifier.
+    If a 'published' DSC contains incorrect and/or insufficient information, a collection manager may ask the research administrator to make it 'editable' again, allowing for changes to be made. If this DSC is modified and thereafter changed to 'published' again, then a second read-only copy is generated. The persistent identifier (DOI) remains the same.
 
     Since the original collection is persistent, it will remain accessible as well. Therefore, carefully check all the files before changing a DSC to 'published'. See :ref:`publish-dsc-share-data`.
 


### PR DESCRIPTION
As requested in Jira, issue 3466 https://radboud.atlassian.net/browse/RDR-3466?atlOrigin=eyJpIjoiMDY4NmE2ZDU2ZGIzNDk2YzhjZmY1OGI2N2VjODY4MWUiLCJwIjoiaiJ9, I have changed the text under question 11 to "If this DSC is modified and thereafter changed to 'published' again, then a second read-only copy is generated. The persistent identifier (DOI) remains the same."