### PR TITLE
hashSignInSucces added variable

### DIFF
--- a/doc/login/hashSignInSuccess.html
+++ b/doc/login/hashSignInSuccess.html
@@ -8,6 +8,6 @@ By accessing this page you agree to the conditions below:<br>
 - You agree that you will not distribute the data in any means or form.<br>
 - Upon completion of the review, you will delete all copies of the data.<br>
 - You agree that you will not attempt to re-identify research participants for any reason.<br>
-- You agree to report any misuse or data release, intentional or inadvertent within 5 business days by e-mailing to <a href="mailto:datasupport@donders.ru.nl">datasupport@donders.ru.nl</a>.<br>
+- You agree to report any misuse or data release, intentional or inadvertent within 5 business days by e-mailing to <a href="mailto:${repositorySupportEmail}">${repositorySupportEmail}</a>.<br>
 
 If you wish to use these data in a research context, including publishing any work using the data, you must await publication of this dataset and, after publication, request access to the data in accordance with the Data Use Agreement.


### PR DESCRIPTION
I have changed the donders e-mail to the variable ${repositorySupportEmail} in the message that appears when an external reviewer succesfully used an invitation URL.