### PR TITLE
Audience field information

### DIFF
--- a/doc/help/user-manual/archive-publish-collections/archive-dac-rdc.rst
+++ b/doc/help/user-manual/archive-publish-collections/archive-dac-rdc.rst
@@ -14,7 +14,7 @@ Only the manager of a collection can archive a collection. To archive a DAC or a
 
 .. figure:: images/RDR_archive_review_internal.png
 
-Details of the collection have to be specified :ref:`see 1.2 <edit-your-collection-details>` before the collection can be archived. The system will give you an error message if some required information is missing.
+Details of the collection have to be specified :ref:`see 1.2 <edit-your-collection-details>` before the collection can be archived. The system will give you an error message if some required information is missing. For Donders Institute researchers, we recommend that you select ‘life sciences’ under the audience field. Also, if you want to add more specific information, you can use the keyword fields to add for example ‘neuroscience’.
 
 A collection can be archived if all the required details are specified. Then you can confirm the switch to "reviewable internal".
 

--- a/doc/help/user-manual/archive-publish-collections/publish-dsc-share-data.rst
+++ b/doc/help/user-manual/archive-publish-collections/publish-dsc-share-data.rst
@@ -15,7 +15,7 @@ By publishing a DSC, your research data are made publicly available. If you do n
 
 When publishing the DSC, you also need to select your "data use agreement" :ref:`(see this FAQ) <faq-data-use-agreement>`
 
-To publish a DSC, you must initially follow the same internal review procedure as described for archiving a :ref:`Data Acquisition Collection (DAC) or a Research Documentation Collection (RDC)<archive-dac-rdc>`.
+To publish a DSC, you must initially follow the same internal review procedure as described for archiving a :ref:`Data Acquisition Collection (DAC) or a Research Documentation Collection (RDC)<archive-dac-rdc>`. **Note:** For Donders Institute researchers, we recommend that you select ‘life sciences’ under the audience field. Also, if you want to add more specific information, you can use the keyword fields to add for example ‘neuroscience’.
 
 .. note::
 


### PR DESCRIPTION
As requested by @miriamkos I have added the sentence "For Donders Institute researchers, we recommend that you select ‘life sciences’ under the audience field. Also, if you want to add more specific information, you can use the keyword fields to add for example ‘neuroscience’." to both archiving and publishing help pages.